### PR TITLE
Update dockerfile because flag `--without` is deprecated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,5 @@ RUN mkdir /convert_service_testing
 WORKDIR /convert_service_testing
 ADD . /convert_service_testing
 RUN gem install bundler
-RUN bundle install --without test development
+RUN bundle config set without 'test development'
 


### PR DESCRIPTION
[DEPRECATED] The `--without` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set without 'test development'`, and stop using this flag