### PR TITLE
Add Addressable gem because it is good way for normalize all filenames.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
+gem 'addressable'
 gem 'onlyoffice_documentserver_conversion_helper', git: 'https://github.com/onlyoffice-testing-robot/onlyoffice_documentserver_conversion_helper.git'
 gem 'onlyoffice_logger_helper', git: 'https://github.com/onlyoffice-testing-robot/onlyoffice_logger_helper.git'
 gem 'onlyoffice_s3_wrapper', git: 'https://github.com/onlyoffice-testing-robot/onlyoffice_s3_wrapper'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,14 @@ GIT
     onlyoffice_logger_helper (1.0.1)
 
 GIT
+  remote: https://github.com/onlyoffice-testing-robot/onlyoffice_s3_wrapper
+  revision: 17ae84e5da2e29e55128f154865637328d5b4626
+  specs:
+    onlyoffice_s3_wrapper (0.1.2)
+      aws-sdk-s3 (~> 1)
+      onlyoffice_file_helper (~> 0.1)
+
+GIT
   remote: https://github.com/onlyoffice-testing-robot/onlyoffice_testrail_wrapper
   revision: f65733e1f142abff942251326739e404f1ac734e
   specs:
@@ -29,6 +37,8 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.0)
     aws-eventstream (1.0.3)
     aws-partitions (1.269.0)
@@ -55,12 +65,10 @@ GEM
     onlyoffice_file_helper (0.1.0)
       onlyoffice_logger_helper (~> 1)
       rubyzip (~> 1.0)
-    onlyoffice_s3_wrapper (0.1.2)
-      aws-sdk-s3 (~> 1)
-      onlyoffice_file_helper (~> 0.1)
     parallel (1.19.1)
     parser (2.7.0.1)
       ast (~> 2.4.0)
+    public_suffix (4.0.3)
     rainbow (3.0.0)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
@@ -90,13 +98,14 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  addressable
   onlyoffice_documentserver_conversion_helper!
   onlyoffice_logger_helper!
-  onlyoffice_s3_wrapper
+  onlyoffice_s3_wrapper!
   onlyoffice_testrail_wrapper!
   palladium!
   rspec
   rubocop
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/spec/convertion_by_format/check_open_docx_by_screen_spec.rb
+++ b/spec/convertion_by_format/check_open_docx_by_screen_spec.rb
@@ -12,8 +12,9 @@ describe 'Convert docx files by convert service' do
       pending 'https://bugzilla.onlyoffice.com/show_bug.cgi?id=32793' if file_path == 'docx/Office Open XML Part 4 - Markup Language Reference.docx'
       pending 'https://bugzilla.onlyoffice.com/show_bug.cgi?id=42324' if file_path == 'docx/SUMMER_APPLICATION_PG_1.docx'
       s3.download_file_by_name('docx/' + File.basename(file_path), './files_tmp')
-      link = StaticData.nginx_url + '/' + URI.encode(File.basename(file_path))
-      response = converter.perform_convert(url: link, outputtype: 'png')
+      link = "#{StaticData.nginx_url}/#{File.basename(file_path)}"
+      uri = Addressable::URI.parse(link)
+      response = converter.perform_convert(url: uri.normalize.to_s, outputtype: 'png')
       expect(response[:url].nil?).to be_falsey
       expect(response[:url].empty?).to be_falsey
     end

--- a/spec/convertion_by_format/check_open_pptx_by_screen_spec.rb
+++ b/spec/convertion_by_format/check_open_pptx_by_screen_spec.rb
@@ -11,8 +11,9 @@ describe 'Convert docx files by convert service' do
       skip 'File without patterns. In will be added by editors. Not converted and its true' if file_path == 'pptx/empty_slides_layouts.pptx'
       skip 'Timeout error. File is too big(92mb)' if file_path == 'pptx/TouhouProject.pptx'
       s3.download_file_by_name('pptx/' + File.basename(file_path), './files_tmp')
-      link = StaticData.nginx_url + '/' + URI.encode(File.basename(file_path))
-      response = converter.perform_convert(url: link, outputtype: 'png')
+      link = "#{StaticData.nginx_url}/#{File.basename(file_path)}"
+      uri = Addressable::URI.parse(link)
+      response = converter.perform_convert(url: uri.normalize.to_s, outputtype: 'png')
       expect(response[:url].nil?).to be_falsey
       expect(response[:url].empty?).to be_falsey
     end

--- a/spec/convertion_by_format/check_open_xlsx_by_screen_spec.rb
+++ b/spec/convertion_by_format/check_open_xlsx_by_screen_spec.rb
@@ -20,8 +20,9 @@ describe 'Convert docx files by convert service' do
       pending 'https://bugzilla.onlyoffice.com/show_bug.cgi?id=42334' if file_path == 'xlsx/_1-3-4-.xlsx'
       pending 'https://bugzilla.onlyoffice.com/show_bug.cgi?id=42334' if file_path == 'xlsx/Customer_Engagement_Workbook_3_0_FY08_External.xlsx'
       s3.download_file_by_name('xlsx/' + File.basename(file_path), './files_tmp')
-      link = StaticData.nginx_url + '/' + URI.encode(File.basename(file_path))
-      response = converter.perform_convert(url: link, outputtype: 'png')
+      link = "#{StaticData.nginx_url}/#{File.basename(file_path)}"
+      uri = Addressable::URI.parse(link)
+      response = converter.perform_convert(url: uri.normalize.to_s, outputtype: 'png')
       expect(response[:url].nil?).to be_falsey
       expect(response[:url].empty?).to be_falsey
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'bundler/setup'
+require 'addressable'
+require 'uri'
 require 'onlyoffice_s3_wrapper'
 require 'onlyoffice_documentserver_conversion_helper'
 require 'onlyoffice_logger_helper/logger_helper'


### PR DESCRIPTION
Normalizing replace all spaces to %20. Using URI.escape is bad way because this method is absolute (rubocop say it).