### PR TITLE
Use `onlyoffice_logger_helper` as gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 gem 'addressable'
 gem 'onlyoffice_documentserver_conversion_helper', git: 'https://github.com/onlyoffice-testing-robot/onlyoffice_documentserver_conversion_helper.git'
-gem 'onlyoffice_logger_helper', git: 'https://github.com/onlyoffice-testing-robot/onlyoffice_logger_helper.git'
+gem 'onlyoffice_logger_helper'
 gem 'onlyoffice_s3_wrapper', git: 'https://github.com/onlyoffice-testing-robot/onlyoffice_s3_wrapper'
 gem 'onlyoffice_testrail_wrapper', git: 'https://github.com/onlyoffice-testing-robot/onlyoffice_testrail_wrapper'
 gem 'palladium', git: 'https://github.com/flaminestone/palladium.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,4 +105,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   2.1.4
+   2.0.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,12 +12,6 @@ GIT
       jwt (~> 2)
 
 GIT
-  remote: https://github.com/onlyoffice-testing-robot/onlyoffice_logger_helper.git
-  revision: 6719da93effe6152454f84ea1a3f7d95437d604b
-  specs:
-    onlyoffice_logger_helper (1.0.1)
-
-GIT
   remote: https://github.com/onlyoffice-testing-robot/onlyoffice_s3_wrapper
   revision: 68fe0b5900b5754832dd3e983a69d17659b01109
   specs:
@@ -65,6 +59,7 @@ GEM
     onlyoffice_file_helper (0.1.0)
       onlyoffice_logger_helper (~> 1)
       rubyzip (~> 1.0)
+    onlyoffice_logger_helper (1.0.2)
     parallel (1.19.1)
     parser (2.7.0.3)
       ast (~> 2.4.0)
@@ -102,7 +97,7 @@ PLATFORMS
 DEPENDENCIES
   addressable
   onlyoffice_documentserver_conversion_helper!
-  onlyoffice_logger_helper!
+  onlyoffice_logger_helper
   onlyoffice_s3_wrapper!
   onlyoffice_testrail_wrapper!
   palladium!
@@ -110,4 +105,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   2.0.2
+   2.1.4


### PR DESCRIPTION
Gem is stable, so no need to install it via git