### PR TITLE
Added always generate a temp file.

### DIFF
--- a/helpers/image_helper.rb
+++ b/helpers/image_helper.rb
@@ -3,6 +3,8 @@
 require 'open-uri'
 require 'tempfile'
 require_relative '../config/StaticData'
+OpenURI::Buffer.send :remove_const, 'StringMax' if OpenURI::Buffer.const_defined?('StringMax')
+OpenURI::Buffer.const_set 'StringMax', 0
 
 # Class for working with images after convert service
 class ImageHelper
@@ -11,7 +13,7 @@ class ImageHelper
   # @return [Integer] size image
   def self.get_image_size(url)
     Tempfile.create('images-') do |tmpfile|
-      binary_image = URI.parse(url).open { |io| io.string.force_encoding Encoding::BINARY }
+      binary_image = URI.parse(url).open(&:read)
       tmpfile.binmode.write binary_image
       tmpfile.size
     end


### PR DESCRIPTION
This change is necessary to standardize the output of information after the conversion server.

The open-uri library uses a constant to set the 10KB size limit for StringIO objects.