### PR TITLE
Add using files with keys instead of using environment variable only

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ ENV S3_KEY ""
 ENV S3_PRIVATE_KEY ""
 ENV PALLADIUM_TOKEN ""
 ENV DOCUMENTSERVER_JWT ""
+RUN mkdir -pv ~/.s3 && \
+    echo $S3_KEY > ~/.s3/key && \
+    echo $S3_PRIVATE_KEY > ~/.s3/private_key
 
 RUN mkdir ~/.documentserver
 RUN echo $DOCUMENTSERVER_JWT > ~/.documentserver/documentserver_jwt


### PR DESCRIPTION
It is need because in 0.3.0. s3_wrapper version, using environment variables has depricated. See [release note](https://github.com/ONLYOFFICE-QA/onlyoffice_s3_wrapper/blob/master/CHANGELOG.md)